### PR TITLE
Remove the timestamp creation of the migration file.

### DIFF
--- a/src/ShoppingcartServiceProvider.php
+++ b/src/ShoppingcartServiceProvider.php
@@ -29,13 +29,8 @@ class ShoppingcartServiceProvider extends ServiceProvider
             }
         });
 
-        if ( ! class_exists('CreateShoppingcartTable')) {
-            // Publish the migration
-            $timestamp = date('Y_m_d_His', time());
-
-            $this->publishes([
-                __DIR__.'/../database/migrations/0000_00_00_000000_create_shoppingcart_table.php' => database_path('migrations/'.$timestamp.'_create_shoppingcart_table.php'),
-            ], 'migrations');
-        }
+        $this->publishes([
+            __DIR__.'/../database/migrations' => database_path('migrations'),
+        ], 'migrations');
     }
 }


### PR DESCRIPTION
By using a different timestamp every time, the publish action creates the migration over and over in the main apps migration directory.

If the filename stays the same, then the file isn't duplicated.